### PR TITLE
feat: support symfony/ux-twig-component v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
-        "symfony/ux-twig-component": "^2.13"
+        "symfony/ux-twig-component": "^2.13 || ^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.94.2",

--- a/tests/Functional/AbstractPicassoKernel.php
+++ b/tests/Functional/AbstractPicassoKernel.php
@@ -54,6 +54,17 @@ abstract class AbstractPicassoKernel extends Kernel
                 'default_path' => '%kernel.project_dir%/templates',
             ]);
 
+            // symfony/ux-twig-component v3 requires "defaults" and "anonymous_template_directory"
+            // to be configured explicitly. v2 accepts the same keys with no change in behaviour
+            // (the bundle declares Picasso:Image via the twig.component tag, not legacy autonaming).
+            // Skip the config when the extension is absent — PicassoTestKernel omits TwigComponentBundle.
+            if ($container->hasExtension('twig_component')) {
+                $container->loadFromExtension('twig_component', [
+                    'anonymous_template_directory' => 'components',
+                    'defaults' => [],
+                ]);
+            }
+
             $this->configureContainer($container);
         });
     }


### PR DESCRIPTION
## Summary

Allows the bundle to be installed alongside `symfony/ux-twig-component` v3, in addition to the existing v2 support.

## What changed

1. **`composer.json`** — widen the constraint:
   ```diff
   -"symfony/ux-twig-component": "^2.13"
   +"symfony/ux-twig-component": "^2.13 || ^3.0"
   ```
   Composer's resolver handles the split automatically: v3 declares `php >=8.4` and `symfony/* ^7.4|^8.0`, so stacks on PHP 8.2/8.3 or Symfony 6.4 naturally stay on v2.

2. **`tests/Functional/AbstractPicassoKernel.php`** — load `twig_component.defaults` and `twig_component.anonymous_template_directory` so the test kernels boot on v3 (both keys are required in v3; v2 accepts them with no behaviour change).

## Why no runtime changes to the bundle

The bundle's only ux-twig-component surface:

| Usage | v2 | v3 |
| --- | --- | --- |
| `#[AsTwigComponent('Picasso:Image', template: ...)]` | ✅ | ✅ unchanged |
| `#[PostMount]` | ✅ | ✅ unchanged |
| `attributes.without('style')` in template | ✅ | ✅ still supported |

Grepped for v3's documented BC-break triggers — zero hits:
- no `cva()` Twig function
- no `ComponentAttributes::add()` calls
- no `PreCreateForRenderEvent::getProps()`
- no `null` values passed as component attributes (template `{% if %}` guards protect this)

## Verified locally

- **v2.35.0**: 434/434 tests pass
- **v3.0.0**: 434/434 tests pass (2 unrelated pre-existing errors in vich/uploader-bundle wiring, also on `main`)

The existing `laminas-ci-matrix-action` configuration already tests minor/major dependency permutations, so CI will exercise both majors.