### PR TITLE
chore: composer validate & normalize quality checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .php-cs-fixer.cache
 .twig-cs-fixer.cache
 /var/
+/config/reference.php

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,13 @@ All bundle exceptions implement `PicassoExceptionInterface` (extends `Throwable`
 - Twig style enforced by Twig-CS-Fixer (`.twig-cs-fixer.php`)
 - Code modernization managed by Rector (`rector.php`) — targets PHP 8.2+, includes deadCode, codeQuality, and typeDeclarations rulesets
 
+### Dependency Constraints
+
+- **Integration libraries** (symfony/_, league/_, imagine, vich, psr/\*, kornrunner/blurhash) keep **wide version ranges** (e.g. `^6.4 || ^7.0 || ^8.0`) so the CI matrix genuinely tests from the lowest to the latest supported versions. Never bump their floors to the currently installed version.
+- **QA tools** (php-cs-fixer, phpstan/\*, phpunit, rector, twig-cs-fixer, composer-normalize) are bumped to current versions via `composer bump:tools`.
+- `config.bump-after-update` was removed on purpose: it bumped **all** dev dependencies after every `composer update`, including integration libraries — do not re-add it.
+- Floors are empirically verified: when changing a floor, run `composer update --prefer-lowest && vendor/bin/phpunit` locally. Known hard floors: `league/glide ^2.3` (needs `Server::setCachePathCallable`), `vich/uploader-bundle ^2.9` (tests use `Metadata\Driver\AttributeDriver`).
+
 ### PHPStan Custom Types
 
 The project uses PHPStan custom type aliases to avoid duplicating complex type annotations across classes. When a structured type is used in multiple files, define it once and import it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,11 @@ All bundle exceptions implement `PicassoExceptionInterface` (extends `Throwable`
 - **Integration libraries** (symfony/_, league/_, imagine, vich, psr/\*, kornrunner/blurhash) keep **wide version ranges** (e.g. `^6.4 || ^7.0 || ^8.0`) so the CI matrix genuinely tests from the lowest to the latest supported versions. Never bump their floors to the currently installed version.
 - **QA tools** (php-cs-fixer, phpstan/\*, phpunit, rector, twig-cs-fixer, composer-normalize) are bumped to current versions via `composer bump:tools`.
 - `config.bump-after-update` was removed on purpose: it bumped **all** dev dependencies after every `composer update`, including integration libraries — do not re-add it.
-- Floors are empirically verified: when changing a floor, run `composer update --prefer-lowest && vendor/bin/phpunit` locally. Known hard floors: `league/glide ^2.3` (needs `Server::setCachePathCallable`), `vich/uploader-bundle ^2.9` (tests use `Metadata\Driver\AttributeDriver`).
+- Floors are empirically verified: when changing a floor, run `composer update --prefer-lowest && vendor/bin/phpunit` locally. Known hard floors:
+    - `league/glide ^2.3` — needs `Server::setCachePathCallable`.
+    - `league/flysystem-bundle ^2.1` — 2.0 only supports Symfony 4/5. Tests must stick to flysystem v2-compatible APIs (`fileExists`, not the v3-only `directoryExists`).
+    - `vich/uploader-bundle ^2.9` — tests use `Metadata\Driver\AttributeDriver` and fixtures use the `Mapping\Attribute` namespace, both introduced in 2.9.
+    - `kornrunner/blurhash ^1.2` — 1.0/1.1 declare PHP `^7.x` only and can never install on this bundle's PHP ≥8.2.
 
 ### PHPStan Custom Types
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "friendsofphp/php-cs-fixer": "^3.94.2",
         "imagine/imagine": "^1.5.2",
         "kornrunner/blurhash": "^1.2",
-        "league/flysystem-bundle": "^3.6",
+        "league/flysystem-bundle": "^2.1 || ^3.0",
         "league/glide": "^2.3 || ^3.0",
         "league/glide-symfony": "^2.0",
         "phpstan/extension-installer": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         "ergebnis/composer-normalize": "^2.52",
         "friendsofphp/php-cs-fixer": "^3.94.2",
         "imagine/imagine": "^1.5.2",
-        "kornrunner/blurhash": "^1.2.2",
-        "league/flysystem-bundle": "^3.6.2",
-        "league/glide": "^2.3.2 || ^3.2",
-        "league/glide-symfony": "^2.1.0",
+        "kornrunner/blurhash": "^1.2",
+        "league/flysystem-bundle": "^3.6",
+        "league/glide": "^2.3 || ^3.0",
+        "league/glide-symfony": "^2.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1.44",
         "phpstan/phpstan-strict-rules": "^2.0",
@@ -24,9 +24,9 @@
         "psr/http-client": "^1.0.3",
         "psr/http-factory": "^1.1",
         "rector/rector": "^2.3.9",
-        "symfony/http-client": "^6.4 || ^7.4.7 || ^8.0.7",
-        "symfony/twig-bundle": "^6.4 || ^7.4.4 || ^8.0.4",
-        "vich/uploader-bundle": "^2.9.2",
+        "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
+        "symfony/twig-bundle": "^6.4 || ^7.0 || ^8.0",
+        "vich/uploader-bundle": "^2.9",
         "vincentlanglet/twig-cs-fixer": "^3.14"
     },
     "suggest": {
@@ -55,13 +55,13 @@
             "ergebnis/composer-normalize": true,
             "phpstan/extension-installer": true
         },
-        "bump-after-update": "dev",
         "preferred-install": {
             "*": "dist"
         },
         "sort-packages": true
     },
     "scripts": {
+        "bump:tools": "@composer bump ergebnis/composer-normalize friendsofphp/php-cs-fixer phpstan/* phpunit/phpunit rector/rector vincentlanglet/twig-cs-fixer",
         "test": "phpunit",
         "test:coverage": "phpunit"
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint-staged": {
         "*.{md,yml,yaml}": "prettier --write",
         "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php",
-        "*.twig": "vendor/bin/twig-cs-fixer lint --fix --config=.twig-cs-fixer.php"
+        "*.twig": "vendor/bin/twig-cs-fixer lint --fix --config=.twig-cs-fixer.php",
+        "composer.json": "composer normalize"
     },
     "scripts": {
         "prepare": "husky"

--- a/tests/Transformer/GlideTransformerPurgeTest.php
+++ b/tests/Transformer/GlideTransformerPurgeTest.php
@@ -65,7 +65,9 @@ class GlideTransformerPurgeTest extends TestCase
 
         $transformer->purge('uploads/photo.jpg', ['transformer' => 'glide', 'loader' => 'filesystem']);
 
-        self::assertFalse($cacheFs->directoryExists('glide/filesystem/uploads/photo.jpg'));
+        // fileExists instead of directoryExists: the latter requires flysystem ^3
+        self::assertFalse($cacheFs->fileExists('glide/filesystem/uploads/photo.jpg/w_300,fm_webp.webp'));
+        self::assertFalse($cacheFs->fileExists('glide/filesystem/uploads/photo.jpg/w_600,fm_avif.avif'));
     }
 
     public function testPurgePublicCacheThrowsWhenTransformerMissing(): void
@@ -99,7 +101,7 @@ class GlideTransformerPurgeTest extends TestCase
 
         $transformer->purge('uploads/photo.jpg', ['transformer' => 'glide', 'loader' => 'filesystem']);
 
-        self::assertFalse($cacheFs->directoryExists('glide/filesystem/uploads/photo.jpg'));
+        self::assertFalse($cacheFs->fileExists('glide/filesystem/uploads/photo.jpg/w_300.webp'));
         self::assertTrue($cacheFs->fileExists('glide/filesystem/uploads/other.jpg/w_300.webp'));
     }
 

--- a/tests/Transformer/ImgixTransformerPurgeTest.php
+++ b/tests/Transformer/ImgixTransformerPurgeTest.php
@@ -54,7 +54,8 @@ class ImgixTransformerPurgeTest extends TestCase
             });
 
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
-        $requestFactory->method('createRequest')
+        $requestFactory->expects(self::once())
+            ->method('createRequest')
             ->with('POST', 'https://api.imgix.com/api/v1/purge')
             ->willReturn($request);
 


### PR DESCRIPTION
Brings composer.json quality enforcement to the bundle (this is the reference implementation the other repos follow):

- `composer validate --strict && composer normalize --dry-run --diff` laminas-ci check
- `ergebnis/composer-normalize` dev dependency + `allow-plugins`
- lint-staged hook running `composer normalize` on `composer.json`
- dependency floors documented/verified (integration libs keep wide ranges; QA tools bumped)
